### PR TITLE
Add install_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ setuptools.setup(
     author="Gido Hakvoort",
     author_email="gido@hakvoort.it",
     description="API wrapper for ROVA calendar",
+    install_requires=["requests"],
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/GidoHakvoort/rova",


### PR DESCRIPTION
[`requests`](https://github.com/GidoHakvoort/rova/blob/6b94b56748608866308afdfae0399039cb0fdb0f/rova/rova.py#L13) is a run-time dependency.